### PR TITLE
add shortNames

### DIFF
--- a/config/crds/autoscaling_v1beta1_cronhorizontalpodautoscaler.yaml
+++ b/config/crds/autoscaling_v1beta1_cronhorizontalpodautoscaler.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: CronHorizontalPodAutoscaler
     plural: cronhorizontalpodautoscalers
+    shortNames:
+      - cronhpa
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
miss shortNames
```shell
# [super kubernetes-cronhpa-controller]$ kubectl get cronhpa
error: the server doesn't have a resource type "cronhpa"
```