### PR TITLE
change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o kubernetes-cronhpa-controller github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/kubernetes-cronhpa-controller
 
 # Copy the controller-manager into a thin image
-FROM scratch
+FROM alpine:3.10
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/AliyunContainerService/kubernetes-cronhpa-controller/kubernetes-cronhpa-controller .
 ENTRYPOINT ["./kubernetes-cronhpa-controller"]

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.aliyuncs.com/acs/kubernetes-cronhpa-controller:v1.3.0-f9010e90-aliyun
+      - image: registry.aliyuncs.com/acs/kubernetes-cronhpa-controller:v1.3.0-8e82633c-aliyun
         name: manager

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.aliyuncs.com/acs/kubernetes-cronhpa-controller:v1.3.0-7f57743a-aliyun
+      - image: registry.aliyuncs.com/acs/kubernetes-cronhpa-controller:v1.3.0-f9010e90-aliyun
         name: manager

--- a/config/deploy/deploy.yaml
+++ b/config/deploy/deploy.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - command:
         - /root/kubernetes-cronhpa-controller
-        image: registry.cn-beijing.aliyuncs.com/acs/kubernetes-cronhpa-controller:v1.3.0-f9010e90-aliyun
+        image: registry.aliyuncs.com/ringtail/kubernetes-cronhpa-controller:v1.3.0-8e82633c-aliyun
         imagePullPolicy: Always
         name: kubernetes-cronhpa-controller
         resources:


### PR DESCRIPTION
Fix the bug in scratch base image.
```
Using the inClusterConfig.  This might not work.
log: exiting because of error: log: cannot create log: open /tmp/*****.unknownuser.log.WARNING.20190117-211751.1: no such file or directory 
```