### PR TITLE
add @date format support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: test kubernetes-cronhpa-controller
 
 # Run tests
 test: generate fmt vet
-	go test github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/... \
+	TRAVIS=true go test github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/... \
 	    github.com/AliyunContainerService/kubernetes-cronhpa-controller/pkg/...  \
 	        -coverprofile cover.out
 

--- a/README.md
+++ b/README.md
@@ -218,9 +218,34 @@ The cronhpa job spec need three fields:
   Hyphens are used to define ranges. For example, 9-17 would indicate every hour between 9am and 5pm inclusive.   
   #### Question mark ( ? )      
   Question mark may be used instead of '*' for leaving either day-of-month or day-of-week blank.
+  #### Predefined schedules
+  You may use one of several pre-defined schedules in place of a cron expression.
+  
+  Entry                  | Description                                | Equivalent To
+  -----                  | -----------                                | -------------
+  @yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 1 1 *
+  @monthly               | Run once a month, midnight, first of month | 0 0 1 * *
+  @weekly                | Run once a week, midnight between Sat/Sun  | 0 0 * * 0
+  @daily (or @midnight)  | Run once a day, midnight                   | 0 0 * * *
+  @hourly                | Run once an hour, beginning of hour        | 0 * * * *
+  Intervals
+  You may also schedule a job to execute at fixed intervals, starting at the time it's added or cron is run. This is supported by formatting the cron spec like this:
+  
+  @every <duration>
+  where "duration" is a string accepted by time.ParseDuration (http://golang.org/pkg/time/#ParseDuration).
+  
+  For example, "@every 1h30m10s" would indicate a schedule that activates after 1 hour, 30 minutes, 10 seconds, and then every interval after that.
+  
+  Note: The interval does not take the job runtime into account. For example, if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes, it will have only 2 minutes of idle time between each run.
   
   more schedule scheme please check this <a target="_blank" href="https://godoc.org/github.com/robfig/cron">doc</a>.
-                                 
+  #### Specific Date (@date)
+  You may use the specific date to schedule a job for scaling the workloads. It is useful when you want to do a daily promotion.  
+   
+  Entry                       | Description                                | Equivalent To
+  -----                       | -----------                                | -------------
+  @date 2020-10-27 21:54:00   | Run once when the date reach               | 0 54 21 27 10 *
+                              
 * targetSize     
   `TargetSize` is the size you desired to scale when the scheduled time arrive. 
   

--- a/examples/deployment_cronhpa_date.yaml
+++ b/examples/deployment_cronhpa_date.yaml
@@ -16,10 +16,10 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.7.9 # replace it with your exactly <image_name:tags>
-        ports:
-        - containerPort: 80
+        - name: nginx
+          image: nginx:1.7.9 # replace it with your exactly <image_name:tags>
+          ports:
+            - containerPort: 80
 ---
 apiVersion: autoscaling.alibabacloud.com/v1beta1
 kind: CronHorizontalPodAutoscaler
@@ -28,14 +28,14 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: cronhpa-sample
 spec:
-   scaleTargetRef:
-      apiVersion: apps/v1beta2
-      kind: Deployment
-      name: nginx-deployment-basic
-   jobs:
-   - name: "scale-down"
-     schedule: "30 */1 * * * *"
-     targetSize: 1
-   - name: "scale-up"
-     schedule: "01 */1 * * * *"
-     targetSize: 3
+  scaleTargetRef:
+    apiVersion: apps/v1beta2
+    kind: Deployment
+    name: nginx-deployment-basic
+  jobs:
+    - name: "scale-down"
+      schedule: "@date 2020-11-16 23:59:00"
+      targetSize: 1
+    - name: "scale-up"
+      schedule: "@date 2020-11-15 00:00:00"
+      targetSize: 3

--- a/examples/deployment_cronhpa_excludeDates.yaml
+++ b/examples/deployment_cronhpa_excludeDates.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2 # for versions before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment-basic

--- a/examples/deployment_cronhpa_runonce.yaml
+++ b/examples/deployment_cronhpa_runonce.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2 # for versions before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment-basic

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/zapr v0.2.0 // indirect; indrect
 	github.com/googleapis/gnostic v0.5.1 // indirect
 	github.com/onsi/gomega v1.10.1
-	github.com/ringtail/go-cron v1.0.1-0.20190829034403-064b52d195fc
+	github.com/ringtail/go-cron v1.0.1-0.20201027122514-cfb21c105f50
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.6.0
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/ringtail/go-cron v1.0.1-0.20190829034403-064b52d195fc h1:SChvpmD1Ptr5R6xPhdIL+myOyp/6fRog7a8msQnlZ6Q=
-github.com/ringtail/go-cron v1.0.1-0.20190829034403-064b52d195fc/go.mod h1:8U/jev/Mhm07q+Z4o0bC1g3WxWdtGlOoSbw9pNyggTI=
+github.com/ringtail/go-cron v1.0.1-0.20201027122514-cfb21c105f50 h1:wZGELP17rE0aWqhLymgCDaU9JZOrn0htJesrlkppakA=
+github.com/ringtail/go-cron v1.0.1-0.20201027122514-cfb21c105f50/go.mod h1:4qPbiKfh9w2ZIKVrH6ulEb6VPnh2ZsJn0coszCd6Nd8=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/vendor/github.com/ringtail/go-cron/go.mod
+++ b/vendor/github.com/ringtail/go-cron/go.mod
@@ -1,0 +1,5 @@
+module github.com/ringtail/go-cron
+
+go 1.15
+
+require github.com/satori/go.uuid v1.2.0

--- a/vendor/github.com/ringtail/go-cron/go.sum
+++ b/vendor/github.com/ringtail/go-cron/go.sum
@@ -1,0 +1,2 @@
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/ringtail/go-cron v1.0.1-0.20190829034403-064b52d195fc
+# github.com/ringtail/go-cron v1.0.1-0.20201027122514-cfb21c105f50
 ## explicit
 github.com/ringtail/go-cron
 # github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
## overview
 You may use the specific date to schedule a job for scaling the workloads. It is useful when you want to do a daily promotion.  
   
  Entry                       | Description                                | Equivalent To
  -----                       | -----------                                | -------------
  @date 2020-10-27 21:54:00   | Run once when the date reach               | 0 54 21 27 10 *

If you use `@date` descriptor then runonce would be enabled by default.  

## demo
```
---
apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1
kind: Deployment
metadata:
  name: nginx-deployment-basic
  labels:
    app: nginx
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:1.7.9 # replace it with your exactly <image_name:tags>
          ports:
            - containerPort: 80
---
apiVersion: autoscaling.alibabacloud.com/v1beta1
kind: CronHorizontalPodAutoscaler
metadata:
  labels:
    controller-tools.k8s.io: "1.0"
  name: cronhpa-sample
spec:
  scaleTargetRef:
    apiVersion: apps/v1beta2
    kind: Deployment
    name: nginx-deployment-basic
  jobs:
    - name: "scale-down"
      schedule: "@date 2020-11-16 23:59:00"
      targetSize: 1
    - name: "scale-up"
      schedule: "@date 2020-11-15 00:00:00"
      targetSize: 3
```