### PR TITLE
feature: add a new metric for outOfDate jobs

### DIFF
--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -45,6 +45,18 @@ var (
 		Help:        "Failed jobs in queue of Cron Engine",
 		ConstLabels: map[string]string{},
 	})
+
+	KubeOutOfDateJobsInCronEngineTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "kube_out_of_date_jobs_in_cron_engine_total",
+		Help:        "OutOfDate jobs in queue of Cron Engine",
+		ConstLabels: map[string]string{},
+	})
+
+	KubeFailedRerunOutOfDateJobsInCronEngineTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "kube_failed_rerun_out_of_date_jobs_in_cron_engine_total",
+		Help:        "Failed rerun OutOfDate jobs in queue of Cron Engine",
+		ConstLabels: map[string]string{},
+	})
 )
 
 func init() {
@@ -56,4 +68,6 @@ func init() {
 	metrics.Registry.MustRegister(KubeSuccessfulJobsInCronEngineTotal)
 	metrics.Registry.MustRegister(KubeFailedJobsInCronEngineTotal)
 	metrics.Registry.MustRegister(KubeExpiredJobsInCronEngineTotal)
+	metrics.Registry.MustRegister(KubeOutOfDateJobsInCronEngineTotal)
+	metrics.Registry.MustRegister(KubeFailedRerunOutOfDateJobsInCronEngineTotal)
 }


### PR DESCRIPTION
Rerunning the outOfDate job fails, which means that the scale up or scale down fails. Need for attention. it should be independent,KubeFailedJobsInCronEngineTotal and KubeSubmittedJobsInCronEngineTotal should not be updated