### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.2 as builder
+FROM golang:1.19 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/AliyunContainerService/kubernetes-cronhpa-controller
@@ -11,7 +11,7 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -a -o kubernetes-cronhpa-controller github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/kubernetes-cronhpa-controller
 
 # Copy the controller-manager into a thin image
-FROM alpine:3.12.0
+FROM alpine:3.17
 RUN apk add --no-cache tzdata
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/AliyunContainerService/kubernetes-cronhpa-controller/kubernetes-cronhpa-controller .


### PR DESCRIPTION
Update Dockerfile in order to solve the build error.
```
 => ERROR [builder 6/6] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -a -o kubernetes-cronhpa-  1.2s
------
 > [builder 6/6] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -a -o kubernetes-cronhpa-controller github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/kubernetes-cronhpa-controller:
0.467 vendor/golang.org/x/net/http2/transport.go:19:2: cannot find package "io/fs" in any of:
0.467   /go/src/github.com/AliyunContainerService/kubernetes-cronhpa-controller/vendor/io/fs (vendor tree)
0.467   /usr/local/go/src/io/fs (from $GOROOT)
0.467   /go/src/io/fs (from $GOPATH)
------
Dockerfile:11
--------------------
   9 |     
  10 |     # Build
  11 | >>> RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -a -o kubernetes-cronhpa-controller github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/kubernetes-cronhpa-controller
  12 |     
  13 |     # Copy the controller-manager into a thin image
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -a -o kubernetes-cronhpa-controller github.com/AliyunContainerService/kubernetes-cronhpa-controller/cmd/kubernetes-cronhpa-controller" did not complete successfully: exit code: 1

```