### PR TITLE
Fix leader election error

### DIFF
--- a/chart/kubernetes-cronhpa-controller/templates/rbac_role.yaml
+++ b/chart/kubernetes-cronhpa-controller/templates/rbac_role.yaml
@@ -28,6 +28,14 @@ rules:
       - watch
       - update
   - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - "configmaps"


### PR DESCRIPTION
I got an error as below:
![image](https://github.com/bogo-y/kubernetes-cronhpa-controller/assets/70442600/864ee19b-ce42-40de-9825-984442aa6396)
I think we need a new rule in rbac_role.yaml to fix it.

Please refer to:
https://github.com/kubernetes-sigs/controller-runtime/pull/1773
https://github.com/AliyunContainerService/kubernetes-cronhpa-controller/pull/125