### PR TITLE
keep active job always same for cronhpa conditions.and call gc immediately。

### DIFF
--- a/chart/kubernetes-cronhpa-controller/templates/deploy.yaml
+++ b/chart/kubernetes-cronhpa-controller/templates/deploy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.enable }}
 # webhook admission controller
 ---
 apiVersion: v1
@@ -70,3 +71,4 @@ spec:
       {{- end }}
 
 
+{{- end }}

--- a/chart/kubernetes-cronhpa-controller/values.yaml
+++ b/chart/kubernetes-cronhpa-controller/values.yaml
@@ -46,3 +46,5 @@ global:
     create: true
 servicemonitor:
   enable: false
+deployment:
+  create: false

--- a/pkg/controller/cronhorizontalpodautoscaler_controller.go
+++ b/pkg/controller/cronhorizontalpodautoscaler_controller.go
@@ -81,7 +81,7 @@ func (r *ReconcileCronHorizontalPodAutoscaler) Reconcile(context context.Context
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			log.Infof("GC start for: cronHPA %s in %s namespace is not found", request.Name, request.Namespace)
-			go r.CronManager.GC()
+			r.CronManager.GC()
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -147,7 +147,6 @@ func (r *ReconcileCronHorizontalPodAutoscaler) Reconcile(context context.Context
 	leftConditionsMap := convertConditionMaps(leftConditions)
 
 	noNeedUpdateStatus := true
-
 	for _, job := range instance.Spec.Jobs {
 		jobCondition := v1beta1.Condition{
 			Name:          job.Name,
@@ -196,6 +195,7 @@ func (r *ReconcileCronHorizontalPodAutoscaler) Reconcile(context context.Context
 		noNeedUpdateStatus = false
 		instance.Status.Conditions = updateConditions(instance.Status.Conditions, jobCondition)
 	}
+	r.CronManager.GC()
 	// conditions are not changed and no need to update.
 	if !noNeedUpdateStatus || len(leftConditions) != len(conditions) {
 		err := r.Update(context, instance)


### PR DESCRIPTION
If cronHPAs with the same job name are frequently created, for example, by calling the update API multiple times quickly or creating a cronHPA after deleting it, the number of running jobs will become abnormal.